### PR TITLE
issue 3801 - legend scrolling on mobile

### DIFF
--- a/src/components/legend/draw.js
+++ b/src/components/legend/draw.js
@@ -277,8 +277,13 @@ module.exports = function draw(gd) {
 
                 var eventY0, eventY1, scrollBoxY0;
 
-                var getScrollBoxDragY = function(scrollBoxY0, eventY0, eventY1) {
+                var getScrollBarDragY = function(scrollBoxY0, eventY0, eventY1) {
                     var y = ((eventY1 - eventY0) / scrollRatio) + scrollBoxY0;
+                    return Lib.constrain(y, 0, scrollBoxYMax);
+                };
+
+                var getNaturalDragY = function(scrollBoxY0, eventY0, eventY1) {
+                    var y = ((eventY0 - eventY1) / scrollRatio) + scrollBoxY0;
                     return Lib.constrain(y, 0, scrollBoxYMax);
                 };
 
@@ -301,7 +306,7 @@ module.exports = function draw(gd) {
                     } else {
                         eventY1 = e.clientY;
                     }
-                    scrollBoxY = getScrollBoxDragY(scrollBoxY0, eventY0, eventY1);
+                    scrollBoxY = getScrollBarDragY(scrollBoxY0, eventY0, eventY1);
                     scrollHandler(scrollBoxY, scrollBarHeight, scrollRatio);
                 });
                 scrollBar.call(scrollBarDrag);
@@ -319,9 +324,8 @@ module.exports = function draw(gd) {
                     var e = d3.event.sourceEvent;
                     if(e.type === 'touchmove') {
                         eventY1 = e.changedTouches[0].clientY;
-                        scrollBoxY = getScrollBoxDragY(scrollBoxY0, eventY0, eventY1);
-                        var naturalScrollBoxY = scrollBoxYMax - scrollBoxY; // inverted for natural-scroll
-                        scrollHandler(naturalScrollBoxY, scrollBarHeight, scrollRatio);
+                        scrollBoxY = getNaturalDragY(scrollBoxY0, eventY0, eventY1);
+                        scrollHandler(scrollBoxY, scrollBarHeight, scrollRatio);
                     }
                 });
                 scrollBox.call(scrollBoxTouchDrag);

--- a/test/jasmine/tests/legend_scroll_test.js
+++ b/test/jasmine/tests/legend_scroll_test.js
@@ -110,7 +110,7 @@ describe('The legend', function() {
                 'translate(0, ' + -finalDataScroll + ')');
         });
 
-        function dragScroll(element, rightClick) {
+        function dragScroll(element, rightClick, mainClick) {
             var scrollBar = getScrollBar();
             var scrollBarBB = scrollBar.getBoundingClientRect();
             var legendHeight = getLegendHeight(gd);
@@ -131,6 +131,10 @@ describe('The legend', function() {
             var x = elBB.left + elBB.width / 2;
 
             var opts = {element: element};
+            if(mainClick) {
+                opts.button = 0;
+                opts.buttons = 2;
+            }
             if(rightClick) {
                 opts.button = 2;
                 opts.buttons = 2;
@@ -155,9 +159,9 @@ describe('The legend', function() {
                 'translate(0, ' + -dataScroll + ')');
         });
 
-        it('should not scroll on dragging the scrollbox', function() {
+        it('should not scroll on dragging the scrollbox with a mouse', function() {
             var scrollBox = getScrollBox();
-            var finalDataScroll = dragScroll(scrollBox);
+            var finalDataScroll = dragScroll(scrollBox, false, true);
 
             var dataScroll = getScroll(gd);
             expect(dataScroll).not.toBeCloseTo(finalDataScroll, 3);


### PR DESCRIPTION
Attempt at fix for [issue 3801](https://github.com/plotly/plotly.js/issues/3801)

With changes:
- scrolls when scrollbar is dragged via mouse or touch
- scrolls when legend is touch-dragged

Not working example, from [issue 3801](https://github.com/plotly/plotly.js/issues/3801):
https://codepen.io/anon/pen/MRqOgE

Working example:
https://codepen.io/anon/pen/yWggJM